### PR TITLE
sets limit to 1000 (max limit) in order to support environments with …

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -93,7 +93,7 @@ export class DataSource extends DataSourceApi<AkenzaQuery, AkenzaDataSourceConfi
 
     async getAssets(): Promise<Asset[]> {
         const params = {
-            unpaged: true,
+            limit: 1000,
             // has to be a string, since the backendSrv just calls toString() on it which results in [Object object] and an API error...
             fields: '{"id": true, "name": true}',
         };


### PR DESCRIPTION
…more than 100 devices (default limit if not set). This is only a temporary fix for unpaged not being available on v2 endpoints...